### PR TITLE
Fix for cfg file changes addressing Diffs - D57614729, D57395613

### DIFF
--- a/src/autoval/lib/test_base.py
+++ b/src/autoval/lib/test_base.py
@@ -302,14 +302,6 @@ class TestBase:
 
         self._process_test_result()
         self.result_handler.print_test_summary()
-        self.print_loaded_modules()
-
-    def print_loaded_modules(self) -> None:
-        """Print loaded modules"""
-        modules = sorted(
-            module for module in sys.modules.keys() if module.startswith("autoval")
-        )
-        logging.info(f"Loaded Modules: {modules}")
 
     def _host_pre_test_operations(self, host_objs: List[Host]) -> None:
         """Arbitrary pre-test actions taken on each host."""

--- a/src/autoval/lib/utils/generic_utils.py
+++ b/src/autoval/lib/utils/generic_utils.py
@@ -240,17 +240,17 @@ class GenericUtils:
     @staticmethod
     # pyre-fixme[24]: Generic type `dict` expects 2 type parameters, use
     #  `typing.Dict[<key type>, <value type>]` to avoid runtime subscripting errors.
-    def read_resource_cfg(file_path: str, module: str = "autoval") -> Dict:
+    def read_resource_cfg(file_path: str, module: str = "autoval", autoval_oss_path: str = "") -> Dict:
         """This function reads the resource json config file and returns the dictionary.
         If the file does not exist, it raises FileNotFoundError
 
-        Assume that we want to read a file located at havoc/autoval/cfg/site_settings/site_settings.json,
+        Assume that we want to read a file located at /autoval/cfg/site_settings/site_settings.json,
         To read this file, caller can call this API as below
-        read_resource_file(file_path="cfg/site_settings/site_settings.json", module="havoc.autoval")
+        read_resource_file(file_path="cfg/site_settings/site_settings.json", module="autoval")
 
         Args:
             file_path: The relative file path from the module directory
-            module: The module name. It must be a valid python package. Default Value : havoc.autoval
+            module: The module name. It must be a valid python package. Default Value : autoval
 
         Returns:
             Resource config file content
@@ -259,7 +259,10 @@ class GenericUtils:
             FileNotFoundError: If resource config file does not exist
         """
         # traceback.print_stack()
-        absolute_file_path = pkg_resources.resource_filename(module, file_path)
+        try:
+            absolute_file_path = pkg_resources.resource_filename(module, file_path)
+        except TypeError:
+            absolute_file_path = autoval_oss_path + "/" + file_path
         AutovalLog.log_debug(
             f"Relative path from {module}: {file_path}, Resolved absolute resource cfg file path: {absolute_file_path}"
         )


### PR DESCRIPTION
The cfg file path had issues due to last minute split of the repository into autoval and autoval-ssd. The absolute file path was picked from autoval-ssd instead of autoval repository. To address this issue D57614729 was raised .
In order to debug , the loaded modules was printed and hence it has to be removed - which was addressed in D57395613.

These changes were done and tested 

