### PR TITLE
Removing debug lines of code

### DIFF
--- a/src/autoval/lib/test_base.py
+++ b/src/autoval/lib/test_base.py
@@ -302,15 +302,7 @@ class TestBase:
 
         self._process_test_result()
         self.result_handler.print_test_summary()
-        self.print_loaded_modules()
-
-    def print_loaded_modules(self) -> None:
-        """Print loaded modules"""
-        modules = sorted(
-            module for module in sys.modules.keys() if module.startswith("autoval")
-        )
-        logging.info(f"Loaded Modules: {modules}")
-
+        
     def _host_pre_test_operations(self, host_objs: List[Host]) -> None:
         """Arbitrary pre-test actions taken on each host."""
         pass

--- a/src/autoval/lib/utils/generic_utils.py
+++ b/src/autoval/lib/utils/generic_utils.py
@@ -244,13 +244,13 @@ class GenericUtils:
         """This function reads the resource json config file and returns the dictionary.
         If the file does not exist, it raises FileNotFoundError
 
-        Assume that we want to read a file located at havoc/autoval/cfg/site_settings/site_settings.json,
+        Assume that we want to read a file located at autoval/cfg/site_settings/site_settings.json,
         To read this file, caller can call this API as below
-        read_resource_file(file_path="cfg/site_settings/site_settings.json", module="havoc.autoval")
+        read_resource_file(file_path="cfg/site_settings/site_settings.json", module="autoval")
 
         Args:
             file_path: The relative file path from the module directory
-            module: The module name. It must be a valid python package. Default Value : havoc.autoval
+            module: The module name. It must be a valid python package. Default Value :autoval
 
         Returns:
             Resource config file content


### PR DESCRIPTION
1. The internal Fb repo names were mentioned and it needs to be removed.

2. In order to debug , the loaded modules was printed and the code was pushed to Git without it being removed.  Hence deleted the print_loaded_modules method as its of no significance

These changes doesn't impact the functionality.

The commits included these 2 changes
