### PR TITLE
Missing slot info fix

### DIFF
--- a/src/autoval/lib/host/bmc.py
+++ b/src/autoval/lib/host/bmc.py
@@ -6,7 +6,7 @@ from typing import List
 
 from autoval.lib.host.credentials import Credentials
 from autoval.lib.test_args import TEST_CONTROL
-from autoval.lib.utils.autoval_exceptions import AutoValException, TestError
+from autoval.lib.utils.autoval_exceptions import AutoValException, TestError, TestInputError
 from autoval.lib.utils.autoval_utils import AutovalLog, AutovalUtils
 
 from autoval.lib.utils.decorators import retry
@@ -84,9 +84,21 @@ class BMC:
         return fru
 
     def _get_slot(self) -> str:
+        """
+        Retrieve the slot number of the host.
+
+        Returns:
+            The slot number of the host.
+        Raises:
+            TestInputError: if the slot cannot be found
+        """
         slot_details = self.run(f"/usr/local/bin/slot-util {self.host.hostname}")
-        slot_number = slot_details.splitlines()[1].strip().split(":")[0]
-        return slot_number
+        if re.search(r"\bslot\d+\b", slot_details):
+            slot_number = slot_details.splitlines()[1].strip().split(":")[0]
+            return slot_number
+        raise TestInputError(
+            "Provide slot details using format slot_info : <slot_number> in test_control"
+        )
 
     def power_status(self) -> str:
         """


### PR DESCRIPTION
Issue:
If the slot_info cannot be fetched from slot util command , the test does not fail and continues until the last step ending up with a command error later .

Solution:
Hence to address this have handled the error in get_slot method, where if /usr/local/bin/slot-util/<host name> didn't fetch a result with slot number then an error will be raised 
Already the best possible regex is being used, so providing slot_info in the test control file is the best feasible solution.

Logs when slot_info is not provided:

[07/04/2024 02:45:21] - Logging to /autoval/results/FE80::E42:A1FF:FEEB:3290%enp94s0np0/DriveDataIntegrityTest/2024-07-04_02-45-21
[07/04/2024 02:45:21] - Runtime cmdlog location: /autoval/results/FE80::E42:A1FF:FEEB:3290%enp94s0np0/DriveDataIntegrityTest/2024-07-04_02-45-21/cmdlog.log
[07/04/2024 02:45:21] - Starting test DriveDataIntegrityTest on FE80::E42:A1FF:FEEB:3290%enp94s0np0
[07/04/2024 02:45:26] - ocp-smart-add-log is not supported on the drive nvme1n1 (MZ1LB960HBJR-000FB).
[07/04/2024 02:45:27] - ocp-smart-add-log is not supported on the drive nvme2n1 (MZ1LB960HBJR-000FB).
[07/04/2024 02:45:28] - ocp-smart-add-log is not supported on the drive nvme0n1 (MTFDHBA512TCK).
[07/04/2024 02:45:28] - Drive info summary:
[07/04/2024 02:45:28] - Manufacturer
[07/04/2024 02:45:28] - 	GenericNVMe: nvme1n1, nvme2n1, nvme0n1
[07/04/2024 02:45:28] - Model
[07/04/2024 02:45:28] - 	MZ1LB960HBJR-000FB: nvme1n1, nvme2n1
[07/04/2024 02:45:28] - 	MTFDHBA512TCK: nvme0n1
[07/04/2024 02:45:28] - Type
[07/04/2024 02:45:28] - 	DriveType.SSD: nvme1n1, nvme2n1, nvme0n1
[07/04/2024 02:45:28] - Interface
[07/04/2024 02:45:28] - 	DriveInterface.NVME: nvme1n1, nvme2n1, nvme0n1
[07/04/2024 02:45:28] - Firmware_version
[07/04/2024 02:45:28] - 	EDW76F2Q: nvme1n1, nvme2n1
[07/04/2024 02:45:28] - 	P1FB003: nvme0n1
[07/04/2024 02:45:28] - Fetching test drives.
[07/04/2024 02:45:28] - Available drives: [nvme1n1, nvme2n1, nvme0n1], Drives under test: [nvme0n1]
[07/04/2024 02:45:28] - ++Skipping umounting before test
[07/04/2024 02:45:28] - Disabling write_cache
[07/04/2024 02:45:28] - Validating write_cache
[07/04/2024 02:45:28] - Write_cache disabling may not supported on boot drive
[07/04/2024 02:45:28] - No degraded drives are present.
[07/04/2024 02:45:28] - Collecting drive data.
[07/04/2024 02:45:29] - ocp-smart-add-log is not supported on the drive nvme1n1 (MZ1LB960HBJR-000FB).
[07/04/2024 02:45:29] - ocp-smart-add-log is not supported on the drive nvme2n1 (MZ1LB960HBJR-000FB).
[07/04/2024 02:45:29] - ocp-smart-add-log is not supported on the drive nvme0n1 (MTFDHBA512TCK).
[07/04/2024 02:45:30] - PASSED - 2 - Test drives list is not empty - Actual: [[nvme0n1]] - Validation: [isNonEmptyList] - Expected: [Non Empty List]
[07/04/2024 02:45:30] - Warning: Did not find UnsuppReg in lspci output, check the drive nvme0n1
[07/04/2024 02:45:30] - ocp-smart-add-log is not supported on the drive nvme0n1 (MTFDHBA512TCK).
[07/04/2024 02:45:30] - ocp-smart-add-log is not supported on the drive nvme0n1 (MTFDHBA512TCK).
[07/04/2024 02:45:30] - umount and remove raid devices
[07/04/2024 02:45:30] - Removing drive's partitions
[07/04/2024 02:45:35] - Skipping BMC-based SSD drive health checking
[07/04/2024 02:45:36] - PASSED - 3 - Run 'nvme id-ctrl /dev/nvme0n1 -H | grep -v fguid' - Actual: [None] - Validation: [isNotException] - Expected: [None]
[07/04/2024 02:45:36] - PASSED - 4 - nvme0n1: Crypto Erase Supported - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/04/2024 02:45:36] - fio version on the host is 3.32
[07/04/2024 02:45:36] - Expected fio version is 3.32
[07/04/2024 02:45:36] - The fio version on the host is greater than the expected version
[07/04/2024 02:45:37] - IP of FE80::E42:A1FF:FEEB:3291%enp94s0np0 with eth0 is: 10::1c8
[07/04/2024 02:45:38] - power-util help: Usage: power-util [ slot1, slot2, slot3, slot4 ] [ status, graceful-shutdown, off, on, reset, cycle, 12V-off, 12V-on, 12V-cycle ]
Usage: power-util sled-cycle
Usage: power-util [ slot1, slot2, slot3, slot4 ] [ device0, device1, device2, device3, device4, device5, device6, device7, device8, device9, device10, device11 ] [ status, off, on, cycle ]
Usage: power-util [ slot1, slot2, slot3, slot4 ] --force [ on, 12V-on ]
[07/04/2024 02:45:40] - Failed to get slot details
[07/04/2024 02:45:40] - FAILED - 5 - [AUTOVAL TEST INPUT ERROR] Provide slot details in format slot_info : <slot_number> in test_control - Actual: [False] - Validation: [isTrue] - Expected: [True]
[07/04/2024 02:45:40] - Starting to clean up drive data integrity test
[07/04/2024 02:45:40] - FAILED - 6 - type object 'AutovalUtils' has no attribute 'fio_process_queue' - Actual: [False] - Validation: [isTrue] - Expected: [True]
[07/04/2024 02:45:40] - Encountered error during failure processing on host FE80::E42:A1FF:FEEB:3290%enp94s0np0 ('SSHConn' object has no attribute 'on_fail')
[07/04/2024 02:45:40] - Failed to collect test manifest data
[07/04/2024 02:45:40] - saving results at /autoval/results/FE80::E42:A1FF:FEEB:3290%enp94s0np0/DriveDataIntegrityTest/2024-07-04_02-45-21/test_results.json
[07/04/2024 02:45:40] - saving test steps at /autoval/results/FE80::E42:A1FF:FEEB:3290%enp94s0np0/DriveDataIntegrityTest/2024-07-04_02-45-21/test_steps.json
[07/04/2024 02:45:40] - +++Test Finished:
Test Summary: DriveDataIntegrityTest Test validates data integrity for different reboot methods Parameters: Cycle type: ac.
Number of iteration: 1
fio jobs ran on DUT while power were cut off.
Passed Steps: 4
Warning Steps: 0
Failed Steps: 2 (Step Number 5, 6)
Test Result : TEST FAILED
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/autoval/lib/test_base.py", line 217, in _setup_execute_teardown
    self._setup_execute()
  File "/usr/local/lib/python3.9/site-packages/autoval/lib/test_base.py", line 45, in wrapper
    self._handle_exception(e)
  File "/usr/local/lib/python3.9/site-packages/autoval/lib/test_base.py", line 43, in wrapper
    func(self, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/autoval/lib/test_base.py", line 373, in _setup_execute
    self._setup()
  File "/usr/local/lib/python3.9/site-packages/autoval/lib/test_base.py", line 379, in _setup
    self.setup()
  File "/home/bin/ocp-diag-autoval-ssd/autoval_ssd/tests/drive_data_integrity/drive_data_integrity.py", line 154, in setup
    self.power_cmd = self._fio_trigger_cmd()
  File "/home/bin/ocp-diag-autoval-ssd/autoval_ssd/tests/drive_data_integrity/drive_data_integrity.py", line 1022, in _fio_trigger_cmd
    power_cmd = self.host.bmc.get_fio_trigger_cmd(
  File "/usr/local/lib/python3.9/site-packages/autoval/lib/host/bmc.py", line 273, in get_fio_trigger_cmd
    ac_cycle_cmd = self.get_cycle_command()["ac"]
  File "/usr/local/lib/python3.9/site-packages/autoval/lib/host/bmc.py", line 292, in get_cycle_command
    slot_id = self.get_fru_name()
  File "/usr/local/lib/python3.9/site-packages/autoval/lib/host/bmc.py", line 79, in get_fru_name
    fru = self._get_slot()
  File "/usr/local/lib/python3.9/site-packages/autoval/lib/host/bmc.py", line 93, in _get_slot
    raise TestInputError(
autoval.lib.utils.autoval_exceptions.TestInputError: [AUTOVAL TEST INPUT ERROR] Provide slot details in format slot_info : <slot_number> in test_control
During handling of the above exception, another exception occurred:
