### PR TITLE
Optional cleanup of server log directory post test execution

### DIFF
--- a/src/autoval/lib/utils/site_utils.py
+++ b/src/autoval/lib/utils/site_utils.py
@@ -393,7 +393,7 @@ class SiteUtils:
         except Exception:
             pass
         # Cleanup DUT log_dirs from all DUT's
-        if connect_to_host:
+        if connect_to_host and cls.get_site_settings().get("cleanup_dut_logdirs", True):
             cls.cleanup_dut_logdirs(hosts)
 
     @classmethod


### PR DESCRIPTION
In this update, we are introducing a flag to control whether or not to skip the post-test cleanup of the DUT log directory for autoVal OSS. Default value being True , cleanup of server log directory will be skipped if provided False.