### PR TITLE
Increasing min uptime value for bmc health check to avoid health chec…

### DIFF
--- a/src/autoval/lib/host/bmc.py
+++ b/src/autoval/lib/host/bmc.py
@@ -31,7 +31,7 @@ class BMC:
     This class represents a BMC (Baseboard Management Controller) and provides methods to interact with it.
     """
 
-    CRITICAL_SERVICES_MIN_UPTIME = 120
+    CRITICAL_SERVICES_MIN_UPTIME = 300
 
     # pyre-fixme[2]: Parameter must be annotated.
     def __init__(self, connection, host) -> None:
@@ -206,7 +206,7 @@ class BMC:
         for service in services:
             self.check_service_uptime(service, self.CRITICAL_SERVICES_MIN_UPTIME)
 
-    @retry(tries=10, sleep_seconds=10)
+    @retry(tries=10, sleep_seconds=30)
     def check_service_uptime(self, service: str, expected_uptime: int) -> None:
         """
         Checks that the uptime of a given service is >= expected uptime. If service is not running, it will be started.


### PR DESCRIPTION
Increasing the minimum uptime value for critical services and increasing retry seconds in the bmc.py file to ensure that the BMC services have enough time to start up before the health check is performed. Below attached pass log for reference.

Pass log: 
[07/22/2024 00:18:13] - Logging to /autoval/results/2620:10d:c0ba:302:1270:fdff:fe18:cbac/FioInternalFlush/2024-07-22_00-18-13
[07/22/2024 00:18:14] - Runtime cmdlog location: /autoval/results/2620:10d:c0ba:302:1270:fdff:fe18:cbac/FioInternalFlush/2024-07-22_00-18-13/cmdlog.log
[07/22/2024 00:18:14] - Starting test FioInternalFlush on 2620:10d:c0ba:302:1270:fdff:fe18:cbac
[07/22/2024 00:18:30] - ocp-smart-add-log is not supported on the drive nvme3n1 (MTFDKBA512TFH).
[07/22/2024 00:18:36] - Drive info summary:
[07/22/2024 00:18:37] - Manufacturer
[07/22/2024 00:18:37] -         GenericNVMe: nvme3n1, nvme0n1, nvme1n1, nvme2n1
[07/22/2024 00:18:37] - Model
[07/22/2024 00:18:37] -         MTFDKBA512TFH: nvme3n1
[07/22/2024 00:18:37] -         HFS3T8GDEZX106N: nvme0n1
[07/22/2024 00:18:37] -         MZOL27T6HBLA-00AFB: nvme1n1, nvme2n1
[07/22/2024 00:18:37] - Type
[07/22/2024 00:18:37] -         DriveType.SSD: nvme3n1, nvme0n1, nvme1n1, nvme2n1
[07/22/2024 00:18:37] - Interface
[07/22/2024 00:18:37] -         DriveInterface.NVME: nvme3n1, nvme0n1, nvme1n1, nvme2n1
[07/22/2024 00:18:37] - Firmware_version
[07/22/2024 00:18:37] -         P7FB000: nvme3n1
[07/22/2024 00:18:37] -         41092F00: nvme0n1
[07/22/2024 00:18:37] -         GEB60F29: nvme1n1, nvme2n1
[07/22/2024 00:18:37] - Fetching test drives.
[07/22/2024 00:18:37] - Available drives: [nvme3n1, nvme0n1, nvme1n1, nvme2n1], Drives under test: [nvme0n1]
[07/22/2024 00:18:37] - ++Skipping umounting before test
[07/22/2024 00:18:37] - Disabling write_cache
[07/22/2024 00:18:38] - Validating write_cache
[07/22/2024 00:18:38] - The drive nvme0n1 not supported write_cache
[07/22/2024 00:18:38] - No degraded drives are present.
[07/22/2024 00:18:38] - Collecting drive data.
[07/22/2024 00:18:39] - ocp-smart-add-log is not supported on the drive nvme3n1 (MTFDKBA512TFH).
[07/22/2024 00:18:43] - PASSED - 1 - Test drives list is not empty - Actual: [[nvme0n1]] - Validation: [isNonEmptyList] - Expected: [Non Empty List]
[07/22/2024 00:18:44] - Warning: Did not find UnsuppReg in lspci output, check the drive nvme0n1
[07/22/2024 00:18:45] - umount and remove raid devices
[07/22/2024 00:18:45] - Removing drive's partitions
[07/22/2024 00:18:51] - Skipping BMC-based SSD drive health checking
[07/22/2024 00:18:51] - PASSED - 2 - Run 'nvme id-ctrl /dev/nvme0n1 -H | grep -v fguid' - Actual: [None] - Validation: [isNotException] - Expected: [None]
[07/22/2024 00:18:51] - PASSED - 3 - nvme0n1: Crypto Erase Supported - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/22/2024 00:18:53] - fio version on the host is 3.35 
[07/22/2024 00:18:53] - Expected fio version is 3.32 
[07/22/2024 00:18:53] - The fio version on the host is greater than the expected version
[07/22/2024 00:18:54] - Expected iops threshold 0.
[07/22/2024 00:18:54] - Expected iops diff threshold 0.2.
[07/22/2024 00:18:54] - Expected latency_100 threshold 100.
[07/22/2024 00:18:54] - PASSED - 4 - Fio setup() - Actual: [None] - Validation: [isNotException] - Expected: [None]
[07/22/2024 00:18:54] - write in progress
[07/22/2024 00:18:55] - Job file used: /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/2620:10d:c0ba:302:1270:fdff:fe18:cbac_nvme_flush_cycle_0_BLKSIZE4k_DEPTH128_RUNTIME5_RWrandwrite_SIZE100G_VERIFYmd5.fio
[07/22/2024 00:18:55] - Starting fio on DUT
[07/22/2024 00:18:55] - Running  FIO command:  fio /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/2620:10d:c0ba:302:1270:fdff:fe18:cbac_nvme_flush_cycle_0_BLKSIZE4k_DEPTH128_RUNTIME5_RWrandwrite_SIZE100G_VERIFYmd5.fio --output-format=json --output=/autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/fio_2620:10d:c0ba:302:1270:fdff:fe18:cbac_2024-07-22_00:18:55.json
[07/22/2024 00:19:00] - FIO output file is copied at: /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/fio_2620:10d:c0ba:302:1270:fdff:fe18:cbac_2024-07-22_00:18:55.json
[07/22/2024 00:19:00] - PASSED - 5 - Ran fio on /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/fio_2620:10d:c0ba:302:1270:fdff:fe18:cbac_2024-07-22_00:18:55.json - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/22/2024 00:19:00] - Parsing results: /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/fio_2620:10d:c0ba:302:1270:fdff:fe18:cbac_2024-07-22_00:18:55.json
[07/22/2024 00:19:00] - PASSED - 6 - Saved results for fio run - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/22/2024 00:19:00] - Compare write iops by model:
[07/22/2024 00:19:00] - PASSED - 7 -  compare by model - HFS3T8GDEZX106N has write iops: 74198 - Actual: [74198] - Validation: [isGreater] - Expected: [0]
[07/22/2024 00:19:00] - Checking latency_ms threshold by model
[07/22/2024 00:19:00] - PASSED - 8 -  compare by model: Validate if the HFS3T8GDEZX106N P100 value of latency_ms is less than 100 - Actual: [0.0] - Validation: [isLess] - Expected: [100]
[07/22/2024 00:19:00] - Compare write iops by cycle:
[07/22/2024 00:19:00] - PASSED - 9 -  compare by cycle - /dev/nvme0n1 has write iops: 74198 - Actual: [74198] - Validation: [isGreater] - Expected: [0]
[07/22/2024 00:19:00] - Checking latency_ms threshold by cycle:
[07/22/2024 00:19:00] - PASSED - 10 -  compare by cycle: Validate if the /dev/nvme0n1 P100 value of latency_ms is less than 100 - Actual: [0.0] - Validation: [isLess] - Expected: [100]
[07/22/2024 00:19:00] - PASSED - 11 - Cycle 1: Fio write job completed. - Actual: [None] - Validation: [isNotException] - Expected: [None]
[07/22/2024 00:19:00] - NVME flush in progress
[07/22/2024 00:19:01] - PASSED - 12 - Run 'nvme flush /dev/nvme0n1' - Actual: [None] - Validation: [isNotException] - Expected: [None]
[07/22/2024 00:19:01] - Reboot in progress
[07/22/2024 00:19:01] - power-util help: Usage: power-util [ slot1, slot2, slot3, slot4 ] [ status, graceful-shutdown, off, on, reset, cycle, 12V-on, 12V-off, 12V-cycle ]
Usage: power-util sled-cycle
Usage: power-util [ slot1, slot2, slot3, slot4 ] [ 1U-dev0, 1U-dev1, 1U-dev2, 1U-dev3, 2U-dev0, 2U-dev1, 2U-dev2, 2U-dev3, 2U-dev4, 2U-dev5, 2U-dev6, 2U-dev7, 2U-dev8, 2U-dev9, 2U-dev10, 2U-dev11, 2U-dev12, 2U-dev13 ] [ status, off, on, cycle ]
[07/22/2024 00:19:03] - Cycling now: /usr/local/bin/power-util slot1 reset
[07/22/2024 00:21:52] - Reconnecting to 2620:10d:c0ba:302:1270:fdff:fe18:cbad...
[07/22/2024 00:21:53] - reconnect successful
[07/22/2024 00:21:56] - PASSED - 15 - Check available drives against initial list. - Actual: [['nvme0n1', 'nvme1n1', 'nvme2n1', 'nvme3n1']] - Validation: [isEqual] - Expected: [['nvme0n1', 'nvme1n1', 'nvme2n1', 'nvme3n1']]
[07/22/2024 00:21:56] - read in progress
[07/22/2024 00:21:57] - Job file used: /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/2620:10d:c0ba:302:1270:fdff:fe18:cbac_nvme_flush_cycle_0_BLKSIZE4k_DEPTH128_RUNTIME5_RWrandread_SIZE100G_VERIFYmd5.fio
[07/22/2024 00:21:57] - Starting fio on DUT
[07/22/2024 00:21:57] - Running  FIO command:  fio /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/2620:10d:c0ba:302:1270:fdff:fe18:cbac_nvme_flush_cycle_0_BLKSIZE4k_DEPTH128_RUNTIME5_RWrandread_SIZE100G_VERIFYmd5.fio --output-format=json --output=/autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/fio_2620:10d:c0ba:302:1270:fdff:fe18:cbac_2024-07-22_00:21:57.json
[07/22/2024 00:22:02] - FIO output file is copied at: /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/fio_2620:10d:c0ba:302:1270:fdff:fe18:cbac_2024-07-22_00:21:57.json
[07/22/2024 00:22:02] - PASSED - 16 - Ran fio on /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/fio_2620:10d:c0ba:302:1270:fdff:fe18:cbac_2024-07-22_00:21:57.json - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/22/2024 00:22:03] - Parsing results: /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/fio_2620:10d:c0ba:302:1270:fdff:fe18:cbac_2024-07-22_00:21:57.json
[07/22/2024 00:22:03] - PASSED - 17 - Saved results for fio run - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/22/2024 00:22:03] - Compare read iops by model:
[07/22/2024 00:22:03] - PASSED - 18 -  compare by model - HFS3T8GDEZX106N has read iops: 40700 - Actual: [40700] - Validation: [isGreater] - Expected: [0]
[07/22/2024 00:22:03] - Checking latency_ms threshold by model
[07/22/2024 00:22:03] - PASSED - 19 -  compare by model: Validate if the HFS3T8GDEZX106N P100 value of latency_ms is less than 100 - Actual: [0.0] - Validation: [isLess] - Expected: [100]
[07/22/2024 00:22:03] - Compare read iops by cycle:
[07/22/2024 00:22:03] - PASSED - 20 -  compare by cycle - /dev/nvme0n1 has read iops: 40700 - Actual: [40700] - Validation: [isGreater] - Expected: [0]
[07/22/2024 00:22:03] - Checking latency_ms threshold by cycle:
[07/22/2024 00:22:03] - PASSED - 21 -  compare by cycle: Validate if the /dev/nvme0n1 P100 value of latency_ms is less than 100 - Actual: [0.0] - Validation: [isLess] - Expected: [100]
[07/22/2024 00:22:03] - PASSED - 22 - Cycle 1: Fio read job completed. - Actual: [None] - Validation: [isNotException] - Expected: [None]
[07/22/2024 00:22:03] - Verify in progress
[07/22/2024 00:22:03] - Job file used: /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/2620:10d:c0ba:302:1270:fdff:fe18:cbac_nvme_flush_cycle_0_BLKSIZE4k_DEPTH128_RWrandread_SIZE100G_VERIFYmd5.fio
[07/22/2024 00:22:03] - Starting fio on DUT
[07/22/2024 00:22:03] - Running  FIO command:  fio /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/2620:10d:c0ba:302:1270:fdff:fe18:cbac_nvme_flush_cycle_0_BLKSIZE4k_DEPTH128_RWrandread_SIZE100G_VERIFYmd5.fio --output-format=json --output=/autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/fio_2620:10d:c0ba:302:1270:fdff:fe18:cbac_2024-07-22_00:22:03.json
[07/22/2024 00:22:13] - FIO output file is copied at: /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/fio_2620:10d:c0ba:302:1270:fdff:fe18:cbac_2024-07-22_00:22:03.json
[07/22/2024 00:22:13] - PASSED - 23 - Ran fio on /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/fio_2620:10d:c0ba:302:1270:fdff:fe18:cbac_2024-07-22_00:22:03.json - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/22/2024 00:22:13] - Parsing results: /autoval/logs/2620_10d_c0ba_302_1270_fdff_fe18_cbac/FioInternalFlush/2024-07-22_00-18-13/fio_2620:10d:c0ba:302:1270:fdff:fe18:cbac_2024-07-22_00:22:03.json
[07/22/2024 00:22:13] - PASSED - 24 - Saved results for fio run - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/22/2024 00:22:13] - Compare read iops by model:
[07/22/2024 00:22:13] - PASSED - 25 -  compare by model - HFS3T8GDEZX106N has read iops: 40763 - Actual: [40763] - Validation: [isGreater] - Expected: [0]
[07/22/2024 00:22:13] - Checking latency_ms threshold by model
[07/22/2024 00:22:13] - PASSED - 26 -  compare by model: Validate if the HFS3T8GDEZX106N P100 value of latency_ms is less than 100 - Actual: [0.0] - Validation: [isLess] - Expected: [100]
[07/22/2024 00:22:13] - Compare read iops by cycle:
[07/22/2024 00:22:13] - PASSED - 27 -  compare by cycle - /dev/nvme0n1 has read iops: 40763 - Actual: [40763] - Validation: [isGreater] - Expected: [0]
[07/22/2024 00:22:13] - Checking latency_ms threshold by cycle:
[07/22/2024 00:22:13] - PASSED - 28 -  compare by cycle: Validate if the /dev/nvme0n1 P100 value of latency_ms is less than 100 - Actual: [0.0] - Validation: [isLess] - Expected: [100]
[07/22/2024 00:22:13] - PASSED - 29 - Cycle 1: Fio verify job completed. - Actual: [None] - Validation: [isNotException] - Expected: [None]
[07/22/2024 00:22:14] - PASSED - 30 - Asserting device names match - Actual: [['nvme0n1', 'nvme1n1', 'nvme2n1', 'nvme3n1', 'nvme3n1p1', 'nvme3n1p2', 'nvme3n1p3']] - Validation: [isEqual] - Expected: [['nvme0n1', 'nvme1n1', 'nvme2n1', 'nvme3n1', 'nvme3n1p1', 'nvme3n1p2', 'nvme3n1p3']]
[07/22/2024 00:22:14] - umount and remove raid devices
[07/22/2024 00:22:15] - Removing drive's partitions
[07/22/2024 00:22:22] - PASSED - 31 - Check available drives against initial list. - Actual: [['nvme0n1', 'nvme1n1', 'nvme2n1', 'nvme3n1']] - Validation: [isEqual] - Expected: [['nvme0n1', 'nvme1n1', 'nvme2n1', 'nvme3n1']]
[07/22/2024 00:22:28] - ocp-smart-add-log is not supported on the drive nvme3n1 (MTFDKBA512TFH).
[07/22/2024 00:22:35] - ocp-smart-add-log is not supported on the drive nvme3n1 (MTFDKBA512TFH).
[07/22/2024 00:22:39] - Lifetime WAF for drive nvme0n1 is 3.965355907116606
[07/22/2024 00:22:39] - PASSED - 54 - WAF expected range - Actual: [3.965355907116606] - Validation: [isWithinRange] - Expected: [Min: 1.0, Max: 20.0]
[07/22/2024 00:22:39] - WAF during this test for drive nvme0n1: 2.492529471202425
[07/22/2024 00:22:39] - Drive nvme0n1: {'lifetime_write_amplification': 3.965355907116606, 'test_write_amplification': 2.492529471202425}
[07/22/2024 00:22:39] - Lifetime WAF for drive nvme1n1 is 1.0002291832931731
[07/22/2024 00:22:39] - PASSED - 55 - WAF expected range - Actual: [1.0002291832931731] - Validation: [isWithinRange] - Expected: [Min: 1.0, Max: 20.0]
[07/22/2024 00:22:39] - WAF during this test for drive nvme1n1: None
[07/22/2024 00:22:39] - Cannot calculate WAF for drive nvme1n1 due to float division by zero
[07/22/2024 00:22:39] - Drive nvme1n1: {'lifetime_write_amplification': 1.0002291832931731, 'test_write_amplification': None}
[07/22/2024 00:22:39] - Lifetime WAF for drive nvme2n1 is 1.0000267240079241
[07/22/2024 00:22:39] - PASSED - 56 - WAF expected range - Actual: [1.0000267240079241] - Validation: [isWithinRange] - Expected: [Min: 1.0, Max: 20.0]
[07/22/2024 00:22:39] - WAF during this test for drive nvme2n1: None
[07/22/2024 00:22:39] - Cannot calculate WAF for drive nvme2n1 due to float division by zero
[07/22/2024 00:22:39] - Drive nvme2n1: {'lifetime_write_amplification': 1.0000267240079241, 'test_write_amplification': None}
[07/22/2024 00:22:39] - Converting storage data for config check
[07/22/2024 00:22:40] - ocp-smart-add-log is not supported on the drive nvme3n1 (MTFDKBA512TFH).
[07/22/2024 00:22:46] - saving config results from storage_test_base at /autoval/results/2620:10d:c0ba:302:1270:fdff:fe18:cbac/FioInternalFlush/2024-07-22_00-18-13/config_results.json
[07/22/2024 00:22:46] - Failed to collect test manifest data
[07/22/2024 00:22:46] - saving results at /autoval/results/2620:10d:c0ba:302:1270:fdff:fe18:cbac/FioInternalFlush/2024-07-22_00-18-13/test_results.json
[07/22/2024 00:22:46] - saving test steps at /autoval/results/2620:10d:c0ba:302:1270:fdff:fe18:cbac/FioInternalFlush/2024-07-22_00-18-13/test_steps.json
[07/22/2024 00:22:46] - +++Test Finished:
Test Summary: FioInternalFlush The test will verify the NVMe drives IO performance with
    fio and following power cycle conditions:
        1. Flush
        2. Shutdown (without Flush)
        3. Dirty power-off! Parameters: Cycle type: warm
Number of iteration: 1
Power_trigger: False
Nvme_flush: True
Passed Steps: 56
Warning Steps: 0
Failed Steps: 0
Test Result : TEST PASSED