### PR TITLE
Power cycle support for YV4

### DIFF
--- a/src/autoval/lib/host/bmc.py
+++ b/src/autoval/lib/host/bmc.py
@@ -3,11 +3,16 @@ import json
 import re
 import time
 from enum import Enum
-from typing import List
+from typing import Optional
 
 from autoval.lib.host.credentials import Credentials
 from autoval.lib.test_args import TEST_CONTROL
-from autoval.lib.utils.autoval_exceptions import AutoValException, TestError
+from autoval.lib.utils.autoval_exceptions import (
+    AutoValException,
+    CmdError,
+    TestError,
+    TestInputError,
+)
 from autoval.lib.utils.autoval_utils import AutovalLog, AutovalUtils
 
 from autoval.lib.utils.decorators import retry
@@ -130,6 +135,9 @@ class BMC:
         Returns:
             str: The power status of the FRU.
         """
+        time.sleep(300)
+        if self.is_busctl_supported():
+            return self.busctl_power_status()
         cmd = f"/usr/local/bin/power-util {self.get_fru_name()} status"
         status = self.run(cmd)
         return status
@@ -178,8 +186,10 @@ class BMC:
         Raises:
             AutoValException: If the reconnection or service check fails, or if the health check does not pass.
         """
+        self.reconnect()  # Should have been named connect?
+        if self.is_busctl_supported():
+            return self.post_cycle_check()
         try:
-            self.reconnect()  # Should have been named connect?
             self.check_services(self.get_critical_services())
             passed = True
         except Exception as exc:
@@ -312,25 +322,74 @@ class BMC:
             raise TestError("No supported trigger command found")
         return cmd
 
+    def is_busctl_supported(self) -> bool:
+        """
+        Check if busctl command is supported on the BMC.
+
+        Returns:
+            bool: True if busctl command is supported, False otherwise.
+        """
+        try:
+            cmd_output = self.bmc_host.run_get_result("busctl help")
+            return cmd_output.return_code == 0
+        except Exception:
+            return False
+
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
     def get_cycle_command(self, slot_id=None):
         """Return dictionary of cycle commands"""
-        boot_dic = {}
-        boot_dic["sled-cycle"] = "/usr/local/bin/power-util sled-cycle"
-        if slot_id is None:
-            slot_id = self.get_fru_name()
-        cmd = "/usr/local/bin/power-util %s" % slot_id
-        boot_dic["ac"] = cmd + " " + "12V-cycle"
-        boot_dic["dc"] = cmd + " " + "cycle"
-        boot_dic["power-on"] = cmd + " " + "on"
-        boot_dic["power-off"] = cmd + " " + "off"
-        boot_dic["power-status"] = cmd + " " + "status"
-        boot_dic["12V-on"] = cmd + " " + "12V-on"
-        boot_dic["12V-off"] = cmd + " " + "12V-off"
-        boot_dic["graceful-shutdown"] = cmd + " " + "graceful-shutdown"
-        boot_dic["reset"] = cmd + " " + "reset"
-        return boot_dic
+        try:
+            if self.is_busctl_supported():
+                boot_dic = {}
+                if slot_id is None:
+                    slot_id = self.get_slot_info()
+                boot_dic["sled-cycle"] = (
+                    "busctl set-property xyz.openbmc_project.State.Chassis0 "
+                    "/xyz/openbmc_project/state/chassis0 "
+                    "xyz.openbmc_project.State.Chassis RequestedPowerTransition s "
+                    "'xyz.openbmc_project.State.Chassis.Transition.PowerCycle'"
+                )
+                cmd = (
+                    f"busctl set-property xyz.openbmc_project.State.Host{slot_id} "
+                    f"/xyz/openbmc_project/state/host{slot_id} "
+                    "xyz.openbmc_project.State.Host RequestedHostTransition s "
+                    "'xyz.openbmc_project.State.Host.Transition."
+                )
+                cmd_ac = (
+                    f"busctl set-property xyz.openbmc_project.State.Chassis{slot_id} "
+                    f"/xyz/openbmc_project/state/chassis{slot_id} "
+                    "xyz.openbmc_project.State.Chassis RequestedPowerTransition s "
+                    "'xyz.openbmc_project.State.Chassis.Transition."
+                )
+                boot_dic["ac"] = cmd_ac + "PowerCycle'"
+                boot_dic["12V-on"] = cmd_ac + "On'"
+                boot_dic["12V-off"] = cmd_ac + "Off'"
+                boot_dic["dc"] = cmd + "Reboot'"
+                boot_dic["power-on"] = cmd + "On'"
+                boot_dic["power-off"] = cmd + "Off'"
+                boot_dic["reset"] = cmd + "GracefulWarmReboot'"
+                boot_dic["graceful-shutdown"] = cmd + "GracefulWarmReboot'"
+            else:
+                boot_dic = {}
+                boot_dic["sled-cycle"] = "/usr/local/bin/power-util sled-cycle"
+                if slot_id is None:
+                    slot_id = self.get_fru_name()
+                cmd = "/usr/local/bin/power-util %s" % slot_id
+                boot_dic["ac"] = cmd + " " + "12V-cycle"
+                boot_dic["dc"] = cmd + " " + "cycle"
+                boot_dic["power-on"] = cmd + " " + "on"
+                boot_dic["power-off"] = cmd + " " + "off"
+                boot_dic["power-status"] = cmd + " " + "status"
+                boot_dic["12V-on"] = cmd + " " + "12V-on"
+                boot_dic["12V-off"] = cmd + " " + "12V-off"
+                boot_dic["graceful-shutdown"] = cmd + " " + "graceful-shutdown"
+                boot_dic["reset"] = cmd + " " + "reset"
+            return boot_dic
+        except Exception as e:
+            # Log any errors that occur during the execution of the method
+            print(f"Error occurred: {e}")
+            return None
 
     def cycle(
         self,
@@ -632,4 +691,110 @@ class BMC:
     # pyre-fixme[2]: Parameter must be annotated.
     def post_cycle_check(self, filter_errors=None) -> None:
         """Check post_cycle"""
+        if self.is_busctl_supported():
+            self.check_bic_status()
         return
+
+    def busctl_power_status(self, slot_info: Optional[int] = None) -> str:
+        """
+        Returns the power status of the device.
+
+        Power is considered to be on if either AC or DC power is on.
+
+        Args:
+            slot_info:  The slot for which to get power status
+
+        Returns:
+            "ON" if the power status is on, "OFF, otherwise.
+
+        Raises:
+            TestError if unable to get power status.
+        """
+        if slot_info is None:
+            slot_info = self.get_slot_info()
+        if self.get_dc_status(slot_info) and self.get_ac_status(slot_info):
+            return "ON"
+        return "OFF"
+
+    def get_slot_info(self) -> int:
+        """
+        Get slot position for busctl supported chassis System.
+        Returns:
+            The slot position of the busctl supported chassis System.
+        """
+        slot_info = TEST_CONTROL.get("slot_info", None)
+        if slot_info:
+            if isinstance(slot_info, str) and slot_info.startswith("slot"):
+                slot_info = slot_info.replace("slot", "")
+            return int(slot_info)
+        raise TestInputError(
+            "Provide slot details using format slot_info: <slot_number> in test_control"
+        )
+
+    @retry(tries=3, sleep_seconds=30, exceptions=CmdError)
+    def get_dc_status(self, slot_info: Optional[int] = None) -> str:
+        """
+        Get the DC status. Retries for 3 times in case of Cmderror.
+        Args:
+            slot_info: The slot number. Defaults to None.
+        Return:
+            True if slot has DC power, False otherwise.
+        """
+        if slot_info is None:
+            slot_info = self.get_slot_info()
+        dc_cmd = (
+            f"gpioget $(basename '/sys/bus/i2c/devices/{slot_info}-0023/'*gpiochip*) 16"
+        )
+        return dc_cmd
+
+    @retry(tries=3, sleep_seconds=30, exceptions=CmdError)
+    def get_ac_status(self, slot_info: Optional[int] = None) -> str:
+        """
+        Checks the AC status. Retries for 3 times in case of Cmderror.
+        Args:
+            slot_info: The slot number. Defaults to None.
+        Returns:
+            True if slot has AC power, False otherwise.
+        """
+        if slot_info is None:
+            slot_info = self.get_slot_info()
+        ac_cmd = (
+            f"gpioget $(basename '/sys/bus/i2c/devices/28-0021/'*gpiochip*) {slot_info}"
+        )
+        return ac_cmd
+
+    def check_bic_status(self, slot_info: Optional[int] = None) -> None:
+        """
+        Get the BIC status and BIC version.
+
+        Args:
+            slot_info: The slot number. Defaults to None.
+
+        """
+        slot_info = self.get_slot_info()
+        bic_version_cmd = f"pldmtool fw_update GetFwParams -m {slot_info}0 | grep 'ActiveComponentImageSetVersionString'"
+        version = self.bmc_host.run(bic_version_cmd, ignore_status=True)
+        match = re.search(
+            r'"ActiveComponentImageSetVersionString"\s*:\s*"([^"]+)"', version
+        )
+        if match:
+            bic_version = match.group(1)
+            AutovalUtils.validate_condition(
+                self.get_bic_status(),
+                f"BIC Status is ON, BIC Version is {bic_version} for {self.host.hostname}",
+            )
+        else:
+            raise TestError("Unable to get BIC version using pldmtool")
+
+    def get_bic_status(self, slot_info: Optional[int] = None) -> bool:
+        """
+        Get the BIC status.
+
+        Return:
+            True if BIC status is ON, False otherwise.
+        """
+        if slot_info is None:
+            slot_info = self.get_slot_info()
+        cmd = f"gpioget $(basename '/sys/bus/i2c/devices/{slot_info}-0024/'gpiochip*) 1"
+        out = self.bmc_host.run(cmd)
+        return out == "1"

--- a/src/autoval/lib/host/system.py
+++ b/src/autoval/lib/host/system.py
@@ -205,7 +205,7 @@ class System:
         Checks the health of the system by verifying the connection and critical systemd services, defined in site settings.
         """
         try:
-            self.check_connection(tries=5, interval=30)
+            self.check_connection(tries=5, interval=60)
             self.check_services(SiteUtils.get_critical_services())
             passed = True
         except Exception as exc:


### PR DESCRIPTION
**Problem:**
Added busctl command support to the current OSS code flow, which previously only supported power-util commands. Hence the tests failed on platforms like YV4 which used busctl instead of power-util

**Solution:**
This update enables compatibility with YV4 systems that utilize busctl commands.

The code is tested on a YV4 system and please find the results below

[manivelaarthi@74512.od /data/sandcastle/boxes/fbsource (37eb9e736)]$ export SITE_SETTINGS=site_settings.json
[manivelaarthi@74512.od /data/sandcastle/boxes/fbsource (37eb9e736)]$ buck-out/v2/gen/fbcode/5433262bffb68588/autoval/__autoval_test_runner__/autoval_test_runner.par autoval_ssd.tests.drive_data_integrity.drive_data_integrity -c config.json  --test_control fbcode/autoval_ssd/tests/drive_data_integrity/di_1_ac_local.json
/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/5433262bffb68588/autoval/__autoval_test_runner__/autoval_test_runner#link-tree/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated and will be removed in a future release
  "class": algorithms.Blowfish,
[05/07/2025 11:34:25] - Logging to /home/manivelaarthi/autoval/results/rtptest075.cco6/DriveDataIntegrityTest/2025-05-07_11-34-25
[05/07/2025 11:34:25] - Runtime cmdlog location: /home/manivelaarthi/autoval/results/rtptest075.cco6/DriveDataIntegrityTest/2025-05-07_11-34-25/cmdlog.log
[05/07/2025 11:34:30] - Starting test DriveDataIntegrityTest on rtptest075.cco6
[05/07/2025 11:35:30] - Drive info summary:
[05/07/2025 11:35:33] - Manufacturer
[05/07/2025 11:35:33] -         GenericNVMe: nvme1n1, nvme0n1
[05/07/2025 11:35:33] - Model
[05/07/2025 11:35:33] -         KXDZDRJJ1T92: nvme1n1
[05/07/2025 11:35:33] -         WUS6A7619PJP8X7: nvme0n1
[05/07/2025 11:35:33] - Type
[05/07/2025 11:35:33] -         DriveType.SSD: nvme1n1, nvme0n1
[05/07/2025 11:35:33] - Interface
[05/07/2025 11:35:33] -         DriveInterface.NVME: nvme1n1, nvme0n1
[05/07/2025 11:35:33] - Firmware_version
[05/07/2025 11:35:33] -         1PFE7107: nvme1n1
[05/07/2025 11:35:33] -         RG109W08: nvme0n1
[05/07/2025 11:35:33] - Fetching test drives.
[05/07/2025 11:35:35] - Available drives: [nvme1n1, nvme0n1], Drives under test: [nvme0n1]
[05/07/2025 11:35:35] - Removing all mounted path
[05/07/2025 11:35:36] - Validating umount all drives
[05/07/2025 11:35:38] - PASSED - 1 - Validating the unmount on drives - Actual: [[]] - Validation: [isEmptyList] - Expected: [[]]
[05/07/2025 11:35:38] - Disabling write_cache
[05/07/2025 11:35:40] - Validating write_cache
[05/07/2025 11:35:41] - The drive nvme0n1 not supported write_cache
[05/07/2025 11:35:43] - No degraded drives are present.
[05/07/2025 11:35:43] - Collecting drive data.
[05/07/2025 11:35:58] - PASSED - 2 - Test drives list is not empty - Actual: [[nvme0n1]] - Validation: [isNonEmptyList] - Expected: [Non Empty List]
[05/07/2025 11:36:01] - Warning: Did not find UnsuppReg in lspci output, check the drive nvme0n1
[05/07/2025 11:36:07] - umount and remove raid devices
[05/07/2025 11:36:09] - Removing drive's partitions
[05/07/2025 11:36:19] - Skipping BMC-based SSD drive health checking
[05/07/2025 11:36:20] - PASSED - 3 - Run 'nvme id-ctrl /dev/nvme0n1 -H | grep -v fguid' - Actual: [None] - Validation: [isNotException] - Expected: [None]
[05/07/2025 11:36:20] - PASSED - 4 - nvme0n1: Crypto Erase Supported - Actual: [True] - Validation: [isTrue] - Expected: [True]
[05/07/2025 11:36:26] - fio version on the host is 3.35 
[05/07/2025 11:36:26] - Expected fio version is 3.32 
[05/07/2025 11:36:26] - The fio version on the host is greater than the expected version
[05/07/2025 11:36:33] - nvme0n1 Saving SMART data at /home/manivelaarthi/autoval/results/rtptest075.cco6/DriveDataIntegrityTest/2025-05-07_11-34-25/SMART/2025-05-07_11:36:33/37240TE0062510.json
[05/07/2025 11:36:41] - Cycle 1
[05/07/2025 11:36:41] - Write in progress
[05/07/2025 11:36:49] - Power trigger enabled and current reboot is 1746642279
[05/07/2025 11:36:49] - Running command: fio /home/manivelaarthi/autoval/logs/rtptest075.cco6/DriveDataIntegrityTest/2025-05-07_11-34-25/fio_results/seq_io_write_cycle_1.fio --output-format=json --output=/home/manivelaarthi/autoval/logs/rtptest075.cco6/DriveDataIntegrityTest/2025-05-07_11-34-25/fio_results/fio-cycle_1_write.log --status-interval=1 --trigger-timeout=90 --trigger='sshpass -p 0penBmc ssh -o StrictHostKeyChecking=no root@2401:db00:26c:582b:face:0:c3:0 "(busctl set-property xyz.openbmc_project.State.Chassis3 /xyz/openbmc_project/state/chassis3 xyz.openbmc_project.State.Chassis RequestedPowerTransition s 'xyz.openbmc_project.State.Chassis.Transition.PowerCycle')" &'
[05/07/2025 11:45:01] - PASSED - 6 - BIC Status is ON, BIC Version is 2025.14.01 for rtptest075.cco6 - Actual: [True] - Validation: [isTrue] - Expected: [True]
[05/07/2025 11:45:01] - PASSED - 7 - Cycle 1: Fio write job completed. - Actual: [None] - Validation: [isNotException] - Expected: [None]
[05/07/2025 11:45:12] - PASSED - 8 - Check available drives against initial list. - Actual: [['nvme0n1', 'nvme1n1']] - Validation: [isEqual] - Expected: [['nvme0n1', 'nvme1n1']]
[05/07/2025 11:45:12] - Read in progress
[05/07/2025 11:45:19] - Running command: fio /home/manivelaarthi/autoval/logs/rtptest075.cco6/DriveDataIntegrityTest/2025-05-07_11-34-25/fio_results/seq_io_read_cycle_1.fio --output-format=json --output=/home/manivelaarthi/autoval/logs/rtptest075.cco6/DriveDataIntegrityTest/2025-05-07_11-34-25/fio_results/fio-cycle_1_read.log
[05/07/2025 11:45:25] - FIO started running
[05/07/2025 11:46:24] - WARNING:  FIO stopped running
[05/07/2025 11:46:31] - WARNING:  FIO stopped running
[05/07/2025 11:51:53] - PASSED - 9 - Cycle 1: Fio read job completed. - Actual: [None] - Validation: [isNotException] - Expected: [None]
[05/07/2025 11:51:53] - INSIDE STOP_FIO_CHECK
[05/07/2025 11:51:53] - WARNING:  FIO stopped running
[05/07/2025 11:51:53] - Verify in progress
[05/07/2025 11:52:01] - Running command: fio /home/manivelaarthi/autoval/logs/rtptest075.cco6/DriveDataIntegrityTest/2025-05-07_11-34-25/fio_results/seq_io_verify_cycle_1.fio --output-format=json --output=/home/manivelaarthi/autoval/logs/rtptest075.cco6/DriveDataIntegrityTest/2025-05-07_11-34-25/fio_results/fio-cycle_1_verify.log
[05/07/2025 11:52:07] - FIO started running
[05/07/2025 11:53:19] - WARNING:  FIO stopped running
[05/07/2025 11:53:26] - WARNING:  FIO stopped running
[05/07/2025 11:58:46] - PASSED - 10 - Cycle 1: Fio verify job completed. - Actual: [None] - Validation: [isNotException] - Expected: [None]
[05/07/2025 11:58:46] - INSIDE STOP_FIO_CHECK
[05/07/2025 11:58:49] - WARNING:  FIO stopped running
[05/07/2025 11:58:49] - PASSED - 11 - Verify Flash Integrity for Cycle - 1 - Actual: [True] - Validation: [isTrue] - Expected: [True]
[05/07/2025 11:59:22] - PASSED - 12 - Check drive availability - Actual: [None] - Validation: [isEqual] - Expected: [None]
[05/07/2025 11:59:22] - Starting to clean up drive data integrity test
[05/07/2025 11:59:22] - INSIDE STOP_FIO_CHECK
[05/07/2025 12:04:30] - PASSED - 13 - Asserting device names match - Actual: [['nvme0n1', 'nvme1n1', 'nvme1n1p1', 'nvme1n1p2']] - Validation: [isEqual] - Expected: [['nvme0n1', 'nvme1n1', 'nvme1n1p1', 'nvme1n1p2']]
[05/07/2025 12:04:35] - umount and remove raid devices
[05/07/2025 12:04:36] - Removing drive's partitions
[05/07/2025 12:04:44] - Removing all mounted path
[05/07/2025 12:04:46] - Validating umount all drives
[05/07/2025 12:04:47] - PASSED - 14 - Validating the unmount on drives - Actual: [[]] - Validation: [isEmptyList] - Expected: [[]]
[05/07/2025 12:04:58] - PASSED - 15 - Check available drives against initial list. - Actual: [['nvme0n1', 'nvme1n1']] - Validation: [isEqual] - Expected: [['nvme0n1', 'nvme1n1']]
[05/07/2025 12:05:45] - Lifetime WAF for drive nvme1n1 is 1.2173097319140287
[05/07/2025 12:05:45] - PASSED - 38 - WAF expected range - Actual: [1.2173097319140287] - Validation: [isWithinRange] - Expected: [Min: 1.0, Max: 20.0]
[05/07/2025 12:05:45] - WAF during this test for drive nvme1n1: 1.5585276705276705
[05/07/2025 12:05:45] - Drive nvme1n1: {'lifetime_write_amplification': 1.2173097319140287, 'test_write_amplification': 1.5585276705276705}
[05/07/2025 12:05:45] - Lifetime WAF for drive nvme0n1 is 1.583246295500073
[05/07/2025 12:05:45] - PASSED - 39 - WAF expected range - Actual: [1.583246295500073] - Validation: [isWithinRange] - Expected: [Min: 1.0, Max: 20.0]
[05/07/2025 12:05:45] - WAF during this test for drive nvme0n1: 1.3752355662200892
[05/07/2025 12:05:45] - Drive nvme0n1: {'lifetime_write_amplification': 1.583246295500073, 'test_write_amplification': 1.3752355662200892}
[05/07/2025 12:05:45] - Converting storage data for config check
[05/07/2025 12:06:03] - saving config results from storage_test_base at /home/manivelaarthi/autoval/results/rtptest075.cco6/DriveDataIntegrityTest/2025-05-07_11-34-25/config_results.json
[05/07/2025 12:06:03] - saving results at /home/manivelaarthi/autoval/results/rtptest075.cco6/DriveDataIntegrityTest/2025-05-07_11-34-25/test_results.json
[05/07/2025 12:06:03] - saving test steps at /home/manivelaarthi/autoval/results/rtptest075.cco6/DriveDataIntegrityTest/2025-05-07_11-34-25/test_steps.json
[05/07/2025 12:06:03] - +++Test Finished:
Test Summary: DriveDataIntegrityTest Test validates data integrity for different reboot methods Parameters: Cycle type: ac.
Number of iteration: 1
fio jobs ran on DUT while power were cut off.
Passed Steps: 39
Warning Steps: 0
Failed Steps: 0
Test Result : TEST PASSED